### PR TITLE
Fix Handlebars Fn's

### DIFF
--- a/scripts/dice-stats-main.js
+++ b/scripts/dice-stats-main.js
@@ -710,7 +710,7 @@ Hooks.once('init', () => {
 
 //handlebars fn used to tell if a die was rolled. 
 //If not display something different then charts and dice stats
-Handlebars.registerHelper('ifDieUsed', function (var1, options) {
+Handlebars.registerHelper('diceStats_ifDieUsed', function (var1, options) {
     if(var1 != 0){
         return options.fn(this);
     }else{
@@ -720,7 +720,7 @@ Handlebars.registerHelper('ifDieUsed', function (var1, options) {
 
 //Handlebars fn used to see if a streak had a blind roll in it.
 //If there was a blind roll we dont want to potentally point the result so dont display it for now
-Handlebars.registerHelper('ifStreakIsBlind', function (var1, options) {
+Handlebars.registerHelper('diceStats_ifStreakIsBlind', function (var1, options) {
     if(var1 != true){
         return options.fn(this);
     }else{
@@ -729,7 +729,7 @@ Handlebars.registerHelper('ifStreakIsBlind', function (var1, options) {
 });
 
 //Handlebars uses this to check if the user has a streak
-Handlebars.registerHelper('ifHaveStreak', function (streakValue, options) {
+Handlebars.registerHelper('diceStats_ifHaveStreak', function (streakValue, options) {
     //If the string has more then 1 number
     if(streakValue.length > 1){
         return options.fn(this);
@@ -739,7 +739,7 @@ Handlebars.registerHelper('ifHaveStreak', function (streakValue, options) {
 });
 
 //Handlebars if Used to check if A Max Or Min Number of the die Was rolled
-Handlebars.registerHelper('ifRolledCrit', function (rollCount, options) {
+Handlebars.registerHelper('diceStats_ifRolledCrit', function (rollCount, options) {
     if(rollCount > 0){
         return options.fn(this);
     }else{
@@ -748,14 +748,14 @@ Handlebars.registerHelper('ifRolledCrit', function (rollCount, options) {
 });
 
 //TODO Display Warning and close popup if user Has no roll data
-Handlebars.registerHelper('ifUserHasData', function (var1, options) {
+Handlebars.registerHelper('diceStats_ifUserHasData', function (var1, options) {
     ui.notifications.warn("No roll data to export");
     return options.inverse(this);
 });
 
 
 //Handlebars helper used to display check on or off on the checkboxes
-Handlebars.registerHelper('isChecked', function (bool, options) {
+Handlebars.registerHelper('diceStats_IsChecked', function (bool, options) {
     if(bool){
         return 'checked="checked"'
     }
@@ -763,7 +763,7 @@ Handlebars.registerHelper('isChecked', function (bool, options) {
 });
 
 //Handlebars helper used to see if we should render die info.
-Handlebars.registerHelper('ifDisplayDieInfo', function (bool, options) {
+Handlebars.registerHelper('diceStats_ifDisplayDieInfo', function (bool, options) {
     if(bool){
         return options.fn(this);
     }
@@ -771,14 +771,14 @@ Handlebars.registerHelper('ifDisplayDieInfo', function (bool, options) {
 });
 
 //Handlebars helper used to check if the client is the GM
-Handlebars.registerHelper('ifIsGM', function (options){
+Handlebars.registerHelper('diceStats_ifIsGM', function (options){
     if(game.user.isGM){
         return options.fn(this);
     }
     return options.inverse(this);
 });
 
-Handlebars.registerHelper('ifHaveBlindRolls', function (blindRollCount, options){
+Handlebars.registerHelper('diceStats_ifHaveBlindRolls', function (blindRollCount, options){
     if(blindRollCount > 0){
         return options.fn(this);
     }

--- a/templates/dice-stats-global.hbs
+++ b/templates/dice-stats-global.hbs
@@ -11,52 +11,52 @@
 
     <!-- Example of using en.json values <li>{{localize "DICE_STATS_TEXT.player-stats-button-title"}} : {{testhandle}}</li>-->
     <div class="form-checkboxes">
-        <input type="checkbox" class="form-checkboxes" data-action="d2checkbox"     {{{isChecked IS_DIE_DISPLAYED.[0]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d2"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d3checkbox"    {{{isChecked IS_DIE_DISPLAYED.[1]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d3"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d4checkbox"     {{{isChecked IS_DIE_DISPLAYED.[2]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d4"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d6checkbox"    {{{isChecked IS_DIE_DISPLAYED.[3]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d6"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d8checkbox"    {{{isChecked IS_DIE_DISPLAYED.[4]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d8"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d10checkbox"    {{{isChecked IS_DIE_DISPLAYED.[5]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d10"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d12checkbox"    {{{isChecked IS_DIE_DISPLAYED.[6]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d12"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d20checkbox"    {{{isChecked IS_DIE_DISPLAYED.[7]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d20"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d100checkbox"    {{{isChecked IS_DIE_DISPLAYED.[8]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d100"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d2checkbox"     {{{diceStats_IsChecked IS_DIE_DISPLAYED.[0]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d2"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d3checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[1]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d3"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d4checkbox"     {{{diceStats_IsChecked IS_DIE_DISPLAYED.[2]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d4"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d6checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[3]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d6"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d8checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[4]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d8"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d10checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[5]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d10"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d12checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[6]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d12"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d20checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[7]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d20"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d100checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[8]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d100"}}</span></input>
     </div>
     <br>
 
-    {{#ifIsGM}}
-    {{#ifHaveBlindRolls TOTAL_BLIND_ROLL_COUNT}}
+    {{#diceStats_ifIsGM}}
+    {{#diceStats_ifHaveBlindRolls TOTAL_BLIND_ROLL_COUNT}}
     <div>
         <h2 class="blind-roll-heading">{{localize "DICE_STATS_TEXT.global_data_form.blind_rolls" ui_rollcount=TOTAL_BLIND_ROLL_COUNT}}</h2>
         <button type="button" data-action="pushBlindRolls">{{localize "DICE_STATS_TEXT.global_data_form.blind_roll_btn"}}</button>
     </div>
     <br>
-    {{/ifHaveBlindRolls}}
-    {{/ifIsGM}}
+    {{/diceStats_ifHaveBlindRolls}}
+    {{/diceStats_ifIsGM}}
     
 
     <div class="col">
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.global_data_form.title"}}</h1>
         <br>
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[0]}}
-        {{#ifDieUsed TOTAL_ROLLS.[0] }} <!-- Associated Helper in Main -->
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[0]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[0] }} <!-- Associated Helper in Main -->
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d2"}}</h1>
         <div id = "d2ChartGlobal" class="chart-dice-stats"></div>
         <table>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_low_roll"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[0]}} <!-- Associated Helper in Main -->
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[0]}} <!-- Associated Helper in Main -->
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MIN_PLAYER.[0] ui_lowRollCnt=ROLLED_MOST_MIN_ROLLCOUNT.[0]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_low_roll"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_high_roll_2"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[0]}}
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[0]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MAX_PLAYER.[0] ui_lowRollCnt=ROLLED_MOST_MAX_ROLLCOUNT.[0]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_high_roll_2"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>    
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.both_forms.table_values.total_rolls"}}</th>
@@ -75,38 +75,38 @@
                 <td>{{MODE.[0]}}</th>
             </tr>
             <tr>
-                {{#ifHaveStreak STREAK.[0]}} <!-- Associated Helper in Main -->
+                {{#diceStats_ifHaveStreak STREAK.[0]}} <!-- Associated Helper in Main -->
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.streak_label" ui_player=STREAK_PLAYER.[0]}}}</td>
                     <td>{{STREAK.[0]}}</td> 
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_streak_label"}}</td>
-                {{/ifHaveStreak}}             
+                {{/diceStats_ifHaveStreak}}             
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
 
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[1]}}
-        {{#ifDieUsed TOTAL_ROLLS.[1] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[1]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[1] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d3"}}</h1>
         <div id = "d3ChartGlobal" class="chart-dice-stats"></div>
         <table>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_low_roll"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[1]}} <!-- Associated Helper in Main -->
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[1]}} <!-- Associated Helper in Main -->
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MIN_PLAYER.[1] ui_lowRollCnt=ROLLED_MOST_MIN_ROLLCOUNT.[1]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_low_roll"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_high_roll_3"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[1]}}
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[1]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MAX_PLAYER.[1] ui_lowRollCnt=ROLLED_MOST_MAX_ROLLCOUNT.[1]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_high_roll_3"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>    
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.both_forms.table_values.total_rolls"}}</th>
@@ -125,38 +125,38 @@
                 <td>{{MODE.[1]}}</th>
             </tr>
             <tr>
-                {{#ifHaveStreak STREAK.[1]}}
+                {{#diceStats_ifHaveStreak STREAK.[1]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.streak_label" ui_player=STREAK_PLAYER.[1]}}}</td>
                     <td>{{STREAK.[1]}}</td> 
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_streak_label"}}</td>
-                {{/ifHaveStreak}}             
+                {{/diceStats_ifHaveStreak}}             
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[2]}}
-        {{#ifDieUsed TOTAL_ROLLS.[2] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[2]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[2] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d4"}}</h1>
         <div id = "d4ChartGlobal" class="chart-dice-stats"></div>
         <table>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_low_roll"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[2]}} <!-- Associated Helper in Main -->
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[2]}} <!-- Associated Helper in Main -->
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MIN_PLAYER.[2] ui_lowRollCnt=ROLLED_MOST_MIN_ROLLCOUNT.[2]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_low_roll"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_high_roll_4"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[2]}}
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[2]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MAX_PLAYER.[2] ui_lowRollCnt=ROLLED_MOST_MAX_ROLLCOUNT.[2]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_high_roll_4"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>    
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.both_forms.table_values.total_rolls"}}</th>
@@ -175,38 +175,38 @@
                 <td>{{MODE.[2]}}</th>
             </tr>
             <tr>
-                {{#ifHaveStreak STREAK.[2]}}
+                {{#diceStats_ifHaveStreak STREAK.[2]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.streak_label" ui_player=STREAK_PLAYER.[2]}}}</td>
                     <td>{{STREAK.[2]}}</td> 
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_streak_label"}}</td>
-                {{/ifHaveStreak}}             
+                {{/diceStats_ifHaveStreak}}             
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[3]}}
-        {{#ifDieUsed TOTAL_ROLLS.[3] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[3]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[3] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d6"}}</h1>
         <div id = "d6ChartGlobal" class="chart-dice-stats"></div>
         <table>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_low_roll"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[3]}} <!-- Associated Helper in Main -->
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[3]}} <!-- Associated Helper in Main -->
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MIN_PLAYER.[3] ui_lowRollCnt=ROLLED_MOST_MIN_ROLLCOUNT.[3]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_low_roll"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_high_roll_6"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[3]}} 
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[3]}} 
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MAX_PLAYER.[3] ui_lowRollCnt=ROLLED_MOST_MAX_ROLLCOUNT.[3]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_high_roll_6"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>    
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.both_forms.table_values.total_rolls"}}</th>
@@ -225,38 +225,38 @@
                 <td>{{MODE.[3]}}</th>
             </tr>
             <tr>
-                {{#ifHaveStreak STREAK.[3]}}
+                {{#diceStats_ifHaveStreak STREAK.[3]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.streak_label" ui_player=STREAK_PLAYER.[3]}}}</td>
                     <td>{{STREAK.[3]}}</td> 
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_streak_label"}}</td>
-                {{/ifHaveStreak}}             
+                {{/diceStats_ifHaveStreak}}             
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[4]}}
-        {{#ifDieUsed TOTAL_ROLLS.[4] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[4]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[4] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d8"}}</h1>
         <div id = "d8ChartGlobal" class="chart-dice-stats"></div>
         <table>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_low_roll"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[4]}} <!-- Associated Helper in Main -->
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[4]}} <!-- Associated Helper in Main -->
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MIN_PLAYER.[4] ui_lowRollCnt=ROLLED_MOST_MIN_ROLLCOUNT.[4]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_low_roll"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_high_roll_8"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[4]}}
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[4]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MAX_PLAYER.[4] ui_lowRollCnt=ROLLED_MOST_MAX_ROLLCOUNT.[4]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_high_roll_8"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>    
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.both_forms.table_values.total_rolls"}}</th>
@@ -275,38 +275,38 @@
                 <td>{{MODE.[4]}}</th>
             </tr>
             <tr>
-                {{#ifHaveStreak STREAK.[4]}}
+                {{#diceStats_ifHaveStreak STREAK.[4]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.streak_label" ui_player=STREAK_PLAYER.[4]}}}</td>
                     <td>{{STREAK.[4]}}</td> 
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_streak_label"}}</td>
-                {{/ifHaveStreak}}            
+                {{/diceStats_ifHaveStreak}}            
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
 
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[5]}}
-        {{#ifDieUsed TOTAL_ROLLS.[5] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[5]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[5] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d10"}}</h1>
         <div id = "d10ChartGlobal" class="chart-dice-stats"></div>
         <table>
            <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_low_roll"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[5]}} <!-- Associated Helper in Main -->
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[5]}} <!-- Associated Helper in Main -->
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MIN_PLAYER.[5] ui_lowRollCnt=ROLLED_MOST_MIN_ROLLCOUNT.[5]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_low_roll"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_high_roll_10"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[5]}}
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[5]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MAX_PLAYER.[5] ui_lowRollCnt=ROLLED_MOST_MAX_ROLLCOUNT.[5]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_high_roll_10"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>    
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.both_forms.table_values.total_rolls"}}</th>
@@ -325,38 +325,38 @@
                 <td>{{MODE.[5]}}</th>
             </tr>
             <tr>
-                {{#ifHaveStreak STREAK.[5]}}
+                {{#diceStats_ifHaveStreak STREAK.[5]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.streak_label" ui_player=STREAK_PLAYER.[5]}}}</td>
                     <td>{{STREAK.[5]}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_streak_label"}}</td>
-                {{/ifHaveStreak}}             
+                {{/diceStats_ifHaveStreak}}             
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[6]}}
-        {{#ifDieUsed TOTAL_ROLLS.[6] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[6]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[6] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d12"}}</h1>
         <div id = "d12ChartGlobal" class="chart-dice-stats"></div>
         <table>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_low_roll"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[6]}} <!-- Associated Helper in Main -->
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[6]}} <!-- Associated Helper in Main -->
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MIN_PLAYER.[6] ui_lowRollCnt=ROLLED_MOST_MIN_ROLLCOUNT.[6]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_low_roll"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_high_roll_12"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[6]}}
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[6]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MAX_PLAYER.[6] ui_lowRollCnt=ROLLED_MOST_MAX_ROLLCOUNT.[6]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_high_roll_12"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>    
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.both_forms.table_values.total_rolls"}}</th>
@@ -375,38 +375,38 @@
                 <td>{{MODE.[6]}}</th>
             </tr>
             <tr>
-                {{#ifHaveStreak STREAK.[6]}}
+                {{#diceStats_ifHaveStreak STREAK.[6]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.streak_label" ui_player=STREAK_PLAYER.[6]}}}</td>
                     <td>{{STREAK.[6]}}</td> 
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_streak_label"}}</td>
-                {{/ifHaveStreak}}             
+                {{/diceStats_ifHaveStreak}}             
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[7]}}
-        {{#ifDieUsed TOTAL_ROLLS.[7] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[7]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[7] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d20"}}</h1>
         <div id = "d20ChartGlobal" class="chart-dice-stats"></div>
         <table>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_low_roll"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[7]}} <!-- Associated Helper in Main -->
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[7]}} <!-- Associated Helper in Main -->
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MIN_PLAYER.[7] ui_lowRollCnt=ROLLED_MOST_MIN_ROLLCOUNT.[7]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_low_roll"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_high_roll_20"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[7]}}
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[7]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MAX_PLAYER.[7] ui_lowRollCnt=ROLLED_MOST_MAX_ROLLCOUNT.[7]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_high_roll_20"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>    
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.both_forms.table_values.total_rolls"}}</th>
@@ -425,38 +425,38 @@
                 <td>{{MODE.[7]}}</th>
             </tr>
             <tr>
-                {{#ifHaveStreak STREAK.[7]}}
+                {{#diceStats_ifHaveStreak STREAK.[7]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.streak_label" ui_player=STREAK_PLAYER.[7]}}}</td>
                     <td>{{STREAK.[7]}}</td> 
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_streak_label"}}</td>
-                {{/ifHaveStreak}}           
+                {{/diceStats_ifHaveStreak}}           
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[8]}}
-        {{#ifDieUsed TOTAL_ROLLS.[8] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[8]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[8] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d100"}}</h1>
         <div id = "d100ChartGlobal" class="chart-dice-stats"></div>
         <table>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_low_roll"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[8]}} <!-- Associated Helper in Main -->
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MIN_ROLLCOUNT.[8]}} <!-- Associated Helper in Main -->
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MIN_PLAYER.[8] ui_lowRollCnt=ROLLED_MOST_MIN_ROLLCOUNT.[8]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_low_roll"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.global_data_form.most_high_roll_100"}}</td>
-                {{#ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[8]}}
+                {{#diceStats_ifRolledCrit ROLLED_MOST_MAX_ROLLCOUNT.[8]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.player_roll_count" ui_player=ROLLED_MOST_MAX_PLAYER.[8] ui_lowRollCnt=ROLLED_MOST_MAX_ROLLCOUNT.[8]}}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_high_roll_100"}}</td>
-                {{/ifRolledCrit}}
+                {{/diceStats_ifRolledCrit}}
             </tr>    
             <tr>
                 <td>{{localize "DICE_STATS_TEXT.both_forms.table_values.total_rolls"}}</th>
@@ -475,16 +475,16 @@
                 <td>{{MODE.[8]}}</th>
             </tr>
             <tr>
-                {{#ifHaveStreak STREAK.[8]}}
+                {{#diceStats_ifHaveStreak STREAK.[8]}}
                     <td>{{{localize "DICE_STATS_TEXT.global_data_form.streak_label" ui_player=STREAK_PLAYER.[8]}}}</td>
                     <td>{{STREAK.[8]}}</td>
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.global_data_form.no_streak_label"}}</td>
-                {{/ifHaveStreak}}        
+                {{/diceStats_ifHaveStreak}}        
             </tr>
         </table>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         <div>
             <button type="button" data-action="refresh">{{localize "DICE_STATS_TEXT.both_forms.refresh_btn"}}</button>
         </div>

--- a/templates/dice-stats-player.hbs
+++ b/templates/dice-stats-player.hbs
@@ -11,29 +11,29 @@
 
     <!-- Example of using en.json values <li>{{localize "DICE_STATS_TEXT.player-stats-button-title"}} : {{testhandle}}</li>-->
     <div class="form-checkboxes">
-        <input type="checkbox" class="form-checkboxes" data-action="d2checkbox"     {{{isChecked IS_DIE_DISPLAYED.[0]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d2"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d3checkbox"    {{{isChecked IS_DIE_DISPLAYED.[1]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d3"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d4checkbox"     {{{isChecked IS_DIE_DISPLAYED.[2]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d4"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d6checkbox"    {{{isChecked IS_DIE_DISPLAYED.[3]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d6"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d8checkbox"    {{{isChecked IS_DIE_DISPLAYED.[4]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d8"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d10checkbox"    {{{isChecked IS_DIE_DISPLAYED.[5]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d10"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d12checkbox"    {{{isChecked IS_DIE_DISPLAYED.[6]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d12"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d20checkbox"    {{{isChecked IS_DIE_DISPLAYED.[7]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d20"}}</span></input>
-        <input type="checkbox" class="form-checkboxes" data-action="d100checkbox"    {{{isChecked IS_DIE_DISPLAYED.[8]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d100"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d2checkbox"     {{{diceStats_IsChecked IS_DIE_DISPLAYED.[0]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d2"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d3checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[1]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d3"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d4checkbox"     {{{diceStats_IsChecked IS_DIE_DISPLAYED.[2]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d4"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d6checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[3]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d6"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d8checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[4]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d8"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d10checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[5]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d10"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d12checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[6]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d12"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d20checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[7]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d20"}}</span></input>
+        <input type="checkbox" class="form-checkboxes" data-action="d100checkbox"    {{{diceStats_IsChecked IS_DIE_DISPLAYED.[8]}}}><span class="form-checkboxes">{{localize "DICE_STATS_TEXT.both_forms.checkboxes.d100"}}</span></input>
     </div>
     <br>
-    {{#ifHaveBlindRolls BLIND_ROLL_COUNT}}
+    {{#diceStats_ifHaveBlindRolls BLIND_ROLL_COUNT}}
     <div class="blind-roll-rollcount">
         <h2>{{localize "DICE_STATS_TEXT.player_data_form.blind_rolls" ui_rolls=BLIND_ROLL_COUNT }}</h2>
     </div>
     <br>
-    {{/ifHaveBlindRolls}}
+    {{/diceStats_ifHaveBlindRolls}}
 
     <div class="col">
         <h1 class="dice-type-title"> {{PLAYER_NAME}} {{localize "DICE_STATS_TEXT.player_data_form.player_name"}}</h1>
         <br>
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[0]}}
-        {{#ifDieUsed TOTAL_ROLLS.[0] }} <!-- Associated Helper in Main -->
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[0]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[0] }} <!-- Associated Helper in Main -->
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d2"}}</h1>
         <div id = "d2Chart" class="chart-dice-stats"></div>
         <table>
@@ -54,25 +54,25 @@
                 <td>{{MODE.[0]}}</th>
             </tr>
             <tr>
-                {{#ifStreakIsBlind S_IS_B.[0]}}     <!--Associated helper in main-->
-                    {{#ifHaveStreak STREAK.[0]}}    <!--Associated helper in main-->
+                {{#diceStats_ifStreakIsBlind S_IS_B.[0]}}     <!--Associated helper in main-->
+                    {{#diceStats_ifHaveStreak STREAK.[0]}}    <!--Associated helper in main-->
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.streak"}}</td>
                         <td>{{STREAK.[0]}}</td> 
                     {{else}}
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.no_streak"}}</td>
-                    {{/ifHaveStreak}}
+                    {{/diceStats_ifHaveStreak}}
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.player_data_form.streak_blind"}}</td>
-                {{/ifStreakIsBlind}}
+                {{/diceStats_ifStreakIsBlind}}
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
 
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[1]}}
-        {{#ifDieUsed TOTAL_ROLLS.[1] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[1]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[1] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d3"}}</h1>
         <div id = "d3Chart" class="chart-dice-stats"></div>
         <table>
@@ -93,25 +93,25 @@
                 <td>{{MODE.[1]}}</th>
             </tr>
             <tr>
-                {{#ifStreakIsBlind S_IS_B.[1]}}  
-                    {{#ifHaveStreak STREAK.[1]}}  
+                {{#diceStats_ifStreakIsBlind S_IS_B.[1]}}  
+                    {{#diceStats_ifHaveStreak STREAK.[1]}}  
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.streak"}}</td>
                         <td>{{STREAK.[1]}}</td> 
                     {{else}}
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.no_streak"}}</td>
-                    {{/ifHaveStreak}}
+                    {{/diceStats_ifHaveStreak}}
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.player_data_form.streak_blind"}}</td>
-                {{/ifStreakIsBlind}}
+                {{/diceStats_ifStreakIsBlind}}
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[2]}}
-        {{#ifDieUsed TOTAL_ROLLS.[2] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[2]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[2] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d4"}}</h1>
         <div id = "d4Chart" class="chart-dice-stats"></div>
         <table>
@@ -132,25 +132,25 @@
                 <td>{{MODE.[2]}}</th>
             </tr>
             <tr>
-                {{#ifStreakIsBlind S_IS_B.[2]}}  
-                    {{#ifHaveStreak STREAK.[2]}}  
+                {{#diceStats_ifStreakIsBlind S_IS_B.[2]}}  
+                    {{#diceStats_ifHaveStreak STREAK.[2]}}  
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.streak"}}</td>
                         <td>{{STREAK.[2]}}</td> 
                     {{else}}
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.no_streak"}}</td>
-                    {{/ifHaveStreak}}
+                    {{/diceStats_ifHaveStreak}}
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.player_data_form.streak_blind"}}</td>
-                {{/ifStreakIsBlind}}
+                {{/diceStats_ifStreakIsBlind}}
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[3]}}
-        {{#ifDieUsed TOTAL_ROLLS.[3] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[3]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[3] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d6"}}</h1>
         <div id = "d6Chart" class="chart-dice-stats"></div>
         <table>
@@ -171,24 +171,24 @@
                 <td>{{MODE.[3]}}</th>
             </tr>
             <tr>
-                {{#ifStreakIsBlind S_IS_B.[3]}}  
-                    {{#ifHaveStreak STREAK.[3]}}  
+                {{#diceStats_ifStreakIsBlind S_IS_B.[3]}}  
+                    {{#diceStats_ifHaveStreak STREAK.[3]}}  
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.streak"}}</td>
                         <td>{{STREAK.[3]}}</td> 
                     {{else}}
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.no_streak"}}</td>
-                    {{/ifHaveStreak}}
+                    {{/diceStats_ifHaveStreak}}
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.player_data_form.streak_blind"}}</td>
-                {{/ifStreakIsBlind}}
+                {{/diceStats_ifStreakIsBlind}}
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[4]}}
-        {{#ifDieUsed TOTAL_ROLLS.[4] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[4]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[4] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d8"}}</h1>
         <div id = "d8Chart" class="chart-dice-stats"></div>
         <table>
@@ -209,24 +209,24 @@
                 <td>{{MODE.[4]}}</th>
             </tr>
             <tr>
-                {{#ifStreakIsBlind S_IS_B.[4]}}  
-                    {{#ifHaveStreak STREAK.[4]}}  
+                {{#diceStats_ifStreakIsBlind S_IS_B.[4]}}  
+                    {{#diceStats_ifHaveStreak STREAK.[4]}}  
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.streak"}}</td>
                         <td>{{STREAK.[4]}}</td> 
                     {{else}}
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.no_streak"}}</td>
-                    {{/ifHaveStreak}}
+                    {{/diceStats_ifHaveStreak}}
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.player_data_form.streak_blind"}}</td>
-                {{/ifStreakIsBlind}}
+                {{/diceStats_ifStreakIsBlind}}
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[5]}}
-        {{#ifDieUsed TOTAL_ROLLS.[5] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[5]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[5] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d10"}}</h1>
         <div id = "d10Chart" class="chart-dice-stats"></div>
         <table>
@@ -247,24 +247,24 @@
                 <td>{{MODE.[5]}}</th>
             </tr>
             <tr>
-                {{#ifStreakIsBlind S_IS_B.[5]}}  
-                    {{#ifHaveStreak STREAK.[5]}}  
+                {{#diceStats_ifStreakIsBlind S_IS_B.[5]}}  
+                    {{#diceStats_ifHaveStreak STREAK.[5]}}  
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.streak"}}</td>
                         <td>{{STREAK.[5]}}</td> 
                     {{else}}
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.no_streak"}}</td>
-                    {{/ifHaveStreak}}
+                    {{/diceStats_ifHaveStreak}}
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.player_data_form.streak_blind"}}</td>
-                {{/ifStreakIsBlind}}
+                {{/diceStats_ifStreakIsBlind}}
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[6]}}
-        {{#ifDieUsed TOTAL_ROLLS.[6] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[6]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[6] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d12"}}</h1>
         <div id = "d12Chart" class="chart-dice-stats"></div>
         <table>
@@ -285,24 +285,24 @@
                 <td>{{MODE.[6]}}</th>
             </tr>
             <tr>
-                {{#ifStreakIsBlind S_IS_B.[6]}}  
-                    {{#ifHaveStreak STREAK.[6]}}  
+                {{#diceStats_ifStreakIsBlind S_IS_B.[6]}}  
+                    {{#diceStats_ifHaveStreak STREAK.[6]}}  
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.streak"}}</td>
                         <td>{{STREAK.[6]}}</td> 
                     {{else}}
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.no_streak"}}</td>
-                    {{/ifHaveStreak}}
+                    {{/diceStats_ifHaveStreak}}
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.player_data_form.streak_blind"}}</td>
-                {{/ifStreakIsBlind}}
+                {{/diceStats_ifStreakIsBlind}}
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[7]}}
-        {{#ifDieUsed TOTAL_ROLLS.[7] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[7]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[7] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d20"}}</h1>
         <div id = "d20Chart" class="chart-dice-stats"></div>
         <table>
@@ -323,24 +323,24 @@
                 <td>{{MODE.[7]}}</th>
             </tr>
             <tr>
-                {{#ifStreakIsBlind S_IS_B.[7]}}  
-                    {{#ifHaveStreak STREAK.[7]}}  
+                {{#diceStats_ifStreakIsBlind S_IS_B.[7]}}  
+                    {{#diceStats_ifHaveStreak STREAK.[7]}}  
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.streak"}}</td>
                         <td>{{STREAK.[7]}}</td> 
                     {{else}}
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.no_streak"}}</td>
-                    {{/ifHaveStreak}}
+                    {{/diceStats_ifHaveStreak}}
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.player_data_form.streak_blind"}}</td>
-                {{/ifStreakIsBlind}}
+                {{/diceStats_ifStreakIsBlind}}
             </tr>
         </table>
         <br>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
         
-        {{#ifDisplayDieInfo IS_DIE_DISPLAYED.[8]}}
-        {{#ifDieUsed TOTAL_ROLLS.[8] }}
+        {{#diceStats_ifDisplayDieInfo IS_DIE_DISPLAYED.[8]}}
+        {{#diceStats_ifDieUsed TOTAL_ROLLS.[8] }}
         <h1 class="dice-type-title">{{localize "DICE_STATS_TEXT.both_forms.section_headings.d100"}}</h1>
         <div id = "d100Chart" class="chart-dice-stats"></div>
         <table>
@@ -361,20 +361,20 @@
                 <td>{{MODE.[8]}}</th>
             </tr>
             <tr>
-                {{#ifStreakIsBlind S_IS_B.[8]}}  
-                    {{#ifHaveStreak STREAK.[8]}}  
+                {{#diceStats_ifStreakIsBlind S_IS_B.[8]}}  
+                    {{#diceStats_ifHaveStreak STREAK.[8]}}  
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.streak"}}</td>
                         <td>{{STREAK.[8]}}</td> 
                     {{else}}
                         <td>{{localize "DICE_STATS_TEXT.player_data_form.no_streak"}}</td>
-                    {{/ifHaveStreak}}
+                    {{/diceStats_ifHaveStreak}}
                 {{else}}
                     <td>{{localize "DICE_STATS_TEXT.player_data_form.streak_blind"}}</td>
-                {{/ifStreakIsBlind}}
+                {{/diceStats_ifStreakIsBlind}}
             </tr>
         </table>
-        {{/ifDieUsed}}
-        {{/ifDisplayDieInfo}}
+        {{/diceStats_ifDieUsed}}
+        {{/diceStats_ifDisplayDieInfo}}
 
         <br>
         <div>


### PR DESCRIPTION
Handlebars fn's could be overwritten if the same fn is used in other modules
Updated handlebars fn names to include module name to drastically reduce potential collisions