### PR TITLE
Fix button collision

### DIFF
--- a/scripts/dice-stats-hooks.js
+++ b/scripts/dice-stats-hooks.js
@@ -129,6 +129,10 @@ Hooks.on("getSceneControlButtons", controls => {
         // Have Scenecontrol as global obj so its not made everytime scenecontrols gets rerendered (this happens alot)
         // Create new button on scene control
         if(GLOBALSCENECONTROLSOBJ == null){
+
+            // Register a new layer for our button
+            CONFIG.Canvas.layers.diceStats = { layerClass: InteractionLayer, group: 'interface' }
+
             let playersAsTools = [];
 
             playersAsTools.push(new CustomSceneControlToolGlobal());

--- a/scripts/forms/dice-stats-scenecontrol.js
+++ b/scripts/forms/dice-stats-scenecontrol.js
@@ -84,7 +84,7 @@ class CustomSceneControl
     activeTool = '';
     name = 'dstats';
     title = 'diceStatsButton';
-    layer = 'controls';
+    layer = 'diceStats';
     icon = 'fas fa-dice-d20';
     visible = true;
     tools = [];

--- a/scripts/forms/dice-stats-scenecontrol.js
+++ b/scripts/forms/dice-stats-scenecontrol.js
@@ -83,7 +83,7 @@ class CustomSceneControl
 {
     activeTool = '';
     name = 'dstats';
-    title = 'diceStatsButton';
+    title = 'Dice Stats';
     layer = 'diceStats';
     icon = 'fas fa-dice-d20';
     visible = true;


### PR DESCRIPTION
When a system or module registers a button before dice-stats is loaded, the button is unusable. This PR registers a new layer (`diceStats`) and uses is to hold the Dice Stats button. Additionally, a pretty name was given to the button.