### PR TITLE
Fix Bug with button not allowing change between scene controlls 1.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG 
-## [ X.XX.X ]
+## [ 1.22.2 ]
+- Add an unused button to dice stats pannel to correct bug. 
+- NOTE: Control will need to be moves to right side buttons to proeprly handle one off buttons rather than the scene controlls.
+- NOTE: Dice stats should not be tied to scenes so it should be moved
 
 ## [ 1.22.1 ]
 - Create v 13 support

--- a/module.json
+++ b/module.json
@@ -59,9 +59,9 @@
     }
   ],
   "socket": true,
-  "version": "1.22.1",
-  "download": "https://github.com/jacobwojoski/dice-stats/archive/refs/tags/v1.22.1.zip",
-  "manifest": "https://github.com/jacobwojoski/dice-stats/releases/download/v1.22.1/module.json",
+  "version": "1.22.2",
+  "download": "https://github.com/jacobwojoski/dice-stats/archive/refs/tags/v1.22.2.zip",
+  "manifest": "https://github.com/jacobwojoski/dice-stats/releases/download/v1.22.2/module.json",
   "changelog": "https://github.com/jacobwojoski/dice-stats/blob/main/CHANGELOG.md",
   "readme": "https://github.com/jacobwojoski/dice-stats",
   "url": "https://github.com/jacobwojoski/dice-stats",

--- a/scripts/asyncinteraction/dice-stats-hooks.js
+++ b/scripts/asyncinteraction/dice-stats-hooks.js
@@ -5,7 +5,7 @@ import { DS_MSG_DIE_ROLL_INFO } from "../appdatastorage/dice-stats-rollmsginfo.j
 import { DS_MSG_ROLL_INFO } from "../appdatastorage/dice-stats-rollmsginfo.js";
 import { DiceStatsTracker } from "../dice-stats-main.js";
 import { DB_INTERACTION } from "../database/dice-stats-db.js";
-import { CustomSceneControl, CustomSceneControlToolCompare, CustomSceneControlToolExport, CustomSceneControlToolGlobal, CustomSceneControlToolPlayer } from "../forms/dice-stats-scenecontrol.js";
+import { CustomSceneControl, CustomSceneControlToolUnused, CustomSceneControlToolCompare, CustomSceneControlToolExport, CustomSceneControlToolGlobal, CustomSceneControlToolPlayer } from "../forms/dice-stats-scenecontrol.js";
 import { DICE_STATS_UTILS } from "../dice-stats-utils.js";
 import { DS_GLOBALS } from "../dice-stats-globals.js";
 import { DiceStatsAPI } from "./dice-stats-api.js";
@@ -195,6 +195,7 @@ Hooks.on("getSceneControlButtons", controls => {
 
         let playersAsTools = [];
 
+        playersAsTools.push(new CustomSceneControlToolUnused())
         playersAsTools.push(new CustomSceneControlToolGlobal());
         playersAsTools.push(new CustomSceneControlToolCompare());
 

--- a/scripts/forms/dice-stats-scenecontrol.js
+++ b/scripts/forms/dice-stats-scenecontrol.js
@@ -149,10 +149,29 @@ export class CustomSceneControlToolExport
     constructor(){}
 }
 
+export class CustomSceneControlToolUnused
+{
+    name = 'Unused';
+    title = 'Unused';
+    icon = 'fa-solid fa-power-off';
+    order= 0;
+
+    visible= true;
+    toggle= false;
+    active= false;
+    button= true;
+
+    async onChange(event, active){
+        console.log("Unused Dice Stats Button")
+    }
+
+    constructor(){}
+}
+
 // Scene Controller outer button to view player buttons
 export class CustomSceneControl
 {
-    activeTool = '';
+    activeTool = 'Unused';
     icon = 'fas fa-dice-d20';
     name = 'dice-stats';
     title = game.i18n.localize('DICE_STATS_TEXT.title');
@@ -169,9 +188,20 @@ export class CustomSceneControl
             tool_cnt++;
             this.tools[tool.name] = tool
         }
+        this.#onChange()
+        this.onChange()
+        this.onToolChange()
     }
 
-    async onChange(event, active){
+    onChange(event, active){
+        console.log("Change Dice Stats Control")
+    }
 
+    #onChange(event, active){
+        console.log("Change Dice Stats Control")
+    }
+    
+    onToolChange(){
+        console.log("Change Dice Stats Tool")
     }
 }


### PR DESCRIPTION
closes #167 

Adds an unused scene control button to fix problem with swapping off a non selected tool. 
v13 changed Scene Controls Buttons and they don't like non selected tools in v13. 